### PR TITLE
[WIP] adding e2e test that automate basic workflow

### DIFF
--- a/test/e2e/basic_workflow_test.go
+++ b/test/e2e/basic_workflow_test.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+// +build !eventing
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"knative.dev/client/lib/test"
+	"knative.dev/client/pkg/util"
+)
+
+func TestBasicWorkflow(t *testing.T) {
+	t.Parallel()
+
+	currentDir, err := os.Getwd()
+	assert.NilError(t, err)
+
+	it, err := NewE2ETest()
+	assert.NilError(t, err)
+	defer func() {
+		assert.NilError(t, it.KnTest().Teardown())
+	}()
+
+	r := test.NewKnRunResultCollector(t, it.KnTest())
+	defer r.DumpIfFailed()
+
+	t.Log("install the consumer and async, redis, and producer components")
+	it.install(t, r)
+
+	t.Log("create demo app")
+	it.createDemoApp(t, r)
+
+	t.Log("test demo app")
+	it.testDemoApp(t, r)
+
+	t.Log("clean up")
+	it.cleanup(t, r)
+}
+
+// Private
+func (it *E2ETest) installConsumer(t *testing.T, r *test.KnRunResultCollector) {
+	out := it.Ko().Run("apply -f config/async/100-async-consumer.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+
+	out = it.Ko().Run("apply -f config/ingress/controller.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+
+	//TODO automate redis install
+
+	out = it.Ko().Run("apply -f config/async/100-async-producer.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+}
+
+func (it *E2ETest) createDemoApp(t, r) {
+	out := it.Kubectl().Run("apply -f test/app/service.yml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+}
+
+func (it *E2ETest) testDemoAppUrl(t, r) string {
+	//TODO automate
+	// 1. get URL for helloworld-sleep
+	// 2. invoke (curl) service non-async and verify responses 200
+	// 3. invoke (curl) service async and verify response 202
+}
+
+func (it *E2ETest) cleanup(t, r) {
+	out := it.Kubectl().Run("delete -f test/app/service.yml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+
+	out = it.Ko().Run("ko delete -f config/async/100-async-producer.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+	
+	out = it.Kubectl().Run("delete -f config/async/100-async-redis-source.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+	
+	out = it.Kubectl().Run("delete -f config/async/tls-secret.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+
+	out = it.Ko().Run("delete -f source/config")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+    
+	out = it.Ko().Run("delete -f config/ingress/controller.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+    
+	out = it.Ko().Run("delete -f config/async/100-async-consumer.yaml")
+	r.AssertNoError(out)
+	assert.Check(t, util.ContainsAllIgnoreCase(out.Stdout, "")) //TODO check output
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"knative.dev/client/lib/test"
+)
+
+type Ko struct {
+}
+
+type Kperf struct {
+	kn: test.Kn
+}
+
+type E2ETest struct {
+	knTest   *test.KnTest
+	kperf *Kperf
+	ko *Ko
+}
+
+// NewE2ETest with params
+func NewE2ETest() (*E2ETest, error) {
+	knTest, err := test.NewKnTest()
+	if err != nil {
+		return nil, err
+	}
+
+	kperf := &Kperf{
+		kn:         knTest.Kn(),
+	}
+
+	ko := &Ko{		
+	}
+
+	e2eTest := &E2ETest{
+		knTest:   knTest,
+		kperf: kperf,
+		ko: ko,
+	}
+
+	return e2eTest, nil
+}
+
+// KnTest object
+func (e2eTest *E2ETest) KnTest() *test.KnTest {
+	return e2eTest.knTest
+}
+
+// Kperf object
+func (e2eTest *E2ETest) Kperf() *Kperf {
+	return e2eTest.kperf
+}
+
+// Ko object
+func (e2eTest *E2ETest) Ko() *Ko {
+	return e2eTest.ko
+}

--- a/test/e2e/ko.go
+++ b/test/e2e/ko.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Knative Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+// Run a command
+func (ko *Ko) Run(cmd string) string {
+	//TODO run ko command
+	return ""
+}
+

--- a/test/local-e2e-tests.sh
+++ b/test/local-e2e-tests.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PATH=$PWD:$PATH
+
+dir=$(dirname "${BASH_SOURCE[0]}")
+base=$(cd "$dir/.." && pwd)
+kn_path=`which kn`
+kperf_path=`which kperf`
+
+# find where kn is located
+check_for_kn() {
+	if [ -z "${KN_PATH}" ]; then
+		if [ -x "${kn_path}" ]; then
+			echo "✅ Found kn executable: $kn_path"
+		else
+			echo "🔥 Could not find kn executable, please add it to your PATH or set KN_PATH"
+			exit -1
+		fi
+	else
+		echo "✅ KN_PATH is set to: $KN_PATH"
+		export PATH=$KN_PATH:$PATH
+	fi
+}
+
+# find where kperf is located
+check_for_kperf() {
+	if [ -z "${KPERF_PATH}" ]; then
+		if [ -x "${kperf_path}" ]; then
+			echo "✅ Found kperf executable: $kperf_path"
+		else
+			echo "🔥 Could not find kperf executable, please add it to your PATH or set KPERF_PATH"
+			exit -1
+		fi
+	else
+		echo "✅ KPERF_PATH is set to: $KPERF_PATH"
+		export PATH=$KPERF_PATH:$PATH
+	fi
+}
+
+# find where ko is located
+check_for_ko() {
+	if [ -z "${KO_PATH}" ]; then
+		if [ -x "${ko_path}" ]; then
+			echo "✅ Found ko executable: $ko_path"
+		else
+			echo "🔥 Could not find ko executable, please add it to your PATH or set KO_PATH"
+			exit -1
+		fi
+	else
+		echo "✅ KO_PATH is set to: $KO_PATH"
+		export PATH=$KO_PATH:$PATH
+	fi
+}
+
+# Will create and delete this namespace (used for all tests, modify if you want a different one used)
+export KNATIVE_ASYNC_E2E_NAMESPACE=knative_async_e2etests
+
+# Make sure `kn` executable is in path
+echo "🔦  Looking for kn"
+check_for_kn
+echo ""
+
+# Make sure `kperf` executable is in path
+echo "🔦  Looking for kperf"
+check_for_kperf
+echo ""
+
+# Make sure `ko` executable is in path
+echo "🔦  Looking for ko"
+check_for_ko
+echo ""
+
+# Start testing
+echo "🧪  Testing"
+go test ${base}/test/e2e/ -test.v -tags "e2e ${E2E_TAGS}" "$@"
+err=$?
+
+# Output
+echo ""
+if [ $err -eq 0 ]; then
+   echo "✅ Success"
+else
+	echo "❗️Failure"
+fi
+
+exit $err


### PR DESCRIPTION
* setup base scaffolding for more e2e in the future
* first e2e basic test

TODOs

- [x] validate `kubectl`, `ko`, and `kn` binary present and tell user to download
- [ ] validate valid Knative cluster is setup
- [ ] create e2e test namespace 
- [ ] validate basic e2e workflow 
- [ ] cleanup tests --- delete namespace

NOTE: this is still work in progress

/WIP

- :gift: Add new feature

/kind enhancement

Fixes #7 

```release-note
e2e test
```